### PR TITLE
Adjusted brand id and postfixes

### DIFF
--- a/cmd/go-mysql-elasticsearch/main.go
+++ b/cmd/go-mysql-elasticsearch/main.go
@@ -124,8 +124,10 @@ func main() {
 	// Add brand ID to Redis key suffix if single DB mode selected and force 0 DB.
 	cfg.RedisKeyPostfix = *redisKeyPostfix
 	if *useSingleRedisDB {
-		cfg.RedisKeyPostfix += fmt.Sprintf("_%d", *brandID)
+		cfg.RedisKeyPostfix += fmt.Sprintf(":%d", *brandID)
 		cfg.RedisDB = 0
+		*redisKeyPostfixSuicideCount += fmt.Sprintf(":%d", *brandID)
+		*redisKeyPostfixAllowedToRun += fmt.Sprintf(":%d", *brandID)
 	}
 
 	// Reconnect to MySQL.


### PR DESCRIPTION
In the bitbucket / shipper-mysql-es repo we can just set the flag `USE_SINGLE_REDIS_DB` to `true` and with this change the keys will look like this:

![image](https://user-images.githubusercontent.com/29961861/64795326-35fed700-d57e-11e9-9c83-c857eeb8057c.png)
