### PR TITLE
Added sync speed variable

### DIFF
--- a/verificator/verificator.go
+++ b/verificator/verificator.go
@@ -170,7 +170,6 @@ func (v *Verificator) doVerificationCheck(r *river.River) error {
 	}
 
 	bytesSyncedSinceLastRun := r.GetPosition().Pos - v.lastSyncedRedisPos
-	fmt.Println("Bytes synced since last run: ", bytesSyncedSinceLastRun)
 
 	if bytesSyncedSinceLastRun > 0 {
 		v.lastSyncedRedisPos = r.GetPosition().Pos


### PR DESCRIPTION
Added logic to get a variable containing the current sync speed. If sync speed is bigger than zero, it will just return out of the verificator that run. 

![image](https://user-images.githubusercontent.com/29961861/65426291-344fd180-de10-11e9-8bd8-4549bd9e3471.png)
